### PR TITLE
Allow overriding supportsInterface()

### DIFF
--- a/contracts/ERC721B.sol
+++ b/contracts/ERC721B.sol
@@ -81,7 +81,7 @@ abstract contract ERC721B {
                               ERC165 LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return
             interfaceId == 0x01ffc9a7 || // ERC165 Interface ID for ERC165
             interfaceId == 0x80ac58cd || // ERC165 Interface ID for ERC721


### PR DESCRIPTION
No need to make this pure, I have to override it in my contract to support ERC2981 royalties.